### PR TITLE
replace  componentWillReceiveProps

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -151,7 +151,7 @@ export class CustomPicker extends React.PureComponent<
     }
   }
 
-  componentWillReceiveProps(nextProps: CustomPickerProps) {
+  componentDidUpdate(nextProps: CustomPickerProps) {
     if (nextProps.value !== this.props.value) {
       this.selectOption(nextProps.value, false)
     }


### PR DESCRIPTION
replace  componentWillReceiveProps tocomponentDidUpdate
Warning: componentWillReceiveProps has been renamed, and is not recommended for use. See https://fb.me/react-async-component-lifecycle-hooks for details.