### PR TITLE
Support landscape orientation on iOS

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -97,6 +97,7 @@ export class CustomPicker extends React.PureComponent<
           visible={this.state.modalVisible}
           onRequestClose={this.hideOptions}
           animationType={modalAnimationType}
+          supportedOrientations={['portrait', 'landscape']}
         >
           <TouchableWithoutFeedback onPress={this.hideOptions}>
             <View


### PR DESCRIPTION
The current implementation changes landscape orientation to portrait when a custom picker modal is shown on iOS device. This PR ensures, that the orientation won’t be changed and the modal will be shown according to the device orientation.